### PR TITLE
an even 20 modules to run smoke tests against

### DIFF
--- a/tests/async.sh
+++ b/tests/async.sh
@@ -1,0 +1,4 @@
+git clone git@github.com:caolan/async.git
+cd async
+npm install --cache-min=9999
+npm test

--- a/tests/bluebird.sh
+++ b/tests/bluebird.sh
@@ -1,0 +1,4 @@
+git clone git@github.com:petkaantonov/bluebird.git
+cd bluebird
+npm install --cache-min=9999
+npm test

--- a/tests/browserify.sh
+++ b/tests/browserify.sh
@@ -1,0 +1,4 @@
+git clone git@github.com:substack/node-browserify.git
+cd node-browserify
+npm install --cache-min=9999
+npm test

--- a/tests/coffeescript.sh
+++ b/tests/coffeescript.sh
@@ -1,0 +1,4 @@
+git clone git@github.com:jashkenas/coffeescript.git
+cd coffeescript
+npm install --cache-min=9999
+npm test

--- a/tests/commander.sh
+++ b/tests/commander.sh
@@ -1,0 +1,4 @@
+git clone git@github.com:tj/commander.js.git
+cd commander.js
+npm install --cache-min=9999
+npm test

--- a/tests/express.sh
+++ b/tests/express.sh
@@ -1,0 +1,4 @@
+git clone git@github.com:strongloop/express.git
+cd express
+npm install --cache-min=9999
+npm test

--- a/tests/glob.sh
+++ b/tests/glob.sh
@@ -1,0 +1,4 @@
+git clone git@github.com:isaacs/node-glob.git
+cd node-glob
+npm install --cache-min=9999
+npm test

--- a/tests/graceful-fs.sh
+++ b/tests/graceful-fs.sh
@@ -1,0 +1,4 @@
+git clone git@github.com:isaacs/node-graceful-fs.git
+cd node-graceful-fs
+npm install --cache-min=9999
+npm test

--- a/tests/grunt.sh
+++ b/tests/grunt.sh
@@ -1,0 +1,4 @@
+git clone git@github.com:gruntjs/grunt.git
+cd grunt
+npm install --cache-min=9999
+npm test

--- a/tests/gulp.sh
+++ b/tests/gulp.sh
@@ -1,0 +1,4 @@
+git clone git@github.com:gulpjs/gulp.git
+cd gulp
+npm install --cache-min=9999
+npm test

--- a/tests/js-yaml.sh
+++ b/tests/js-yaml.sh
@@ -1,0 +1,4 @@
+git clone git@github.com:nodeca/js-yaml.git
+cd js-yaml
+npm install --cache-min=9999
+npm test

--- a/tests/mkdirp.sh
+++ b/tests/mkdirp.sh
@@ -1,0 +1,4 @@
+git clone git@github.com:substack/node-mkdirp.git
+cd node-mkdirp
+npm install --cache-min=9999
+npm test

--- a/tests/q.sh
+++ b/tests/q.sh
@@ -1,0 +1,4 @@
+git clone git@github.com:kriskowal/q.git
+cd q
+npm install --cache-min=9999
+npm test

--- a/tests/shelljs.sh
+++ b/tests/shelljs.sh
@@ -1,0 +1,4 @@
+git clone git@github.com:arturadib/shelljs.git
+cd shelljs
+npm install --cache-min=9999
+npm test

--- a/tests/superagent.sh
+++ b/tests/superagent.sh
@@ -1,0 +1,4 @@
+git clone git@github.com:visionmedia/superagent.git
+cd superagent
+npm install --cache-min=9999
+npm test

--- a/tests/through2.sh
+++ b/tests/through2.sh
@@ -1,0 +1,4 @@
+git clone git@github.com:rvagg/through2.git
+cd through2
+npm install --cache-min=9999
+npm test


### PR DESCRIPTION
The added modules are all selected from the most-depended-upon and most-downloaded lists. They all have test suites that can be run with `npm test` and have no external dependencies. They all also have test suites that pass right now.

In addition, pulled in a couple of fun modules that will keep the `fs` module honest. 